### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: build
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number'
+        required: true
+        type: string
+
+jobs:
+
+  jlink:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'liberica'
+          java-version: '18'
+          architecture: x64
+
+      - name: version
+        run: mvn -B versions:set -DnewVersion="${{ inputs.version }}"
+
+      - name: build
+        run: mvn --batch-mode clean javafx:jlink
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}
+          path: target/*.zip
+


### PR DESCRIPTION
I created a `.github/workflows/build.yml` file,
which can be manually triggered via the `Actions` tab on GitHub.

It basically runs `mvn javafx:jlink`, for Linux, Windows and Mac, and then "uploads"/attaches the zips to the build so one can download them. There's probably more convenient ways to do this...

One of the good things with this,
is that a user does not need to build the application themselves and they don't need to have Java installed on their computer!

![actions](https://github.com/TBestLittleHelper/SimpleGraphApplication/assets/4084220/b794029b-a9b7-4853-87f1-aad45c384495)
